### PR TITLE
Add script to simplify deploymoent

### DIFF
--- a/terraform.sh
+++ b/terraform.sh
@@ -476,6 +476,7 @@ function help() {
     echo "  --destroy     Destroy Terraform-managed infrastructure"
     echo "  --hosts       Generate hosts.yaml file but do not run wizard"
     echo "  --wipe        Wipe tfvars and .env.sh"
+    echo "  --data        Outputs useful info"
     echo "  -d, --domain  Used with --hosts will change the default nip.io to this domain"
     echo "  -h, --help      Display this help message"
 
@@ -483,7 +484,7 @@ function help() {
 
 function data() {
     tfvars_output
-    print_header "Additional usefull commands"
+    print_header "Additional useful commands"
     echo "# Create dynamic proxy via SSH"
     echo " ssh -A -D 5900 $metallb_lb_pub_ip "
     echo " "


### PR DESCRIPTION
The purpose of this is to add a new script and other changes that simplifies the process of deploying fuzzball. 

- Adds `terraform.sh` script
  - This will prompt for various inputs that will create the tfvars file
  - The script will then attempt to run `terraform apply` (requires approval from user) to deploy the infrastructure to vultr
  - Using the output from terraform we then generate a `hosts.yaml` file for ansible
    - This is not run by default but does output the appropriate command to run
  - You can rerun the apply by appending `--apply` to the command
  - You can destroy the terraform infrastructure with the `--destroy` flag
  - You can regenerate the hosts file with `--hosts`
  - You can delete the `.env.sh` and the `tfvars` with `--wipe`
  - Note: This currently only generates the hosts.yaml file with support for
- Various changes were made to terraform to support this
  - Added region variable
  - Added output.tf to grab info like IP addresses used in terraform.sh
- .gitignore was updated with two additional fukes