### PR TITLE
Enable RKE2 to launch at boot

### DIFF
--- a/roles/rke2/tasks/main.yaml
+++ b/roles/rke2/tasks/main.yaml
@@ -32,10 +32,12 @@
     dest: /etc/rancher/rke2/config.yaml
     mode: 0644
 
-- name: Start RKE2
+- name: Start and Enable RKE2
   ansible.builtin.service:
     name: rke2-server
     state: started
+    enabled: true
+    
 
 - name: Install Local Path Provisioner
   kubernetes.core.k8s:

--- a/roles/rke2/tasks/main.yaml
+++ b/roles/rke2/tasks/main.yaml
@@ -37,7 +37,6 @@
     name: rke2-server
     state: started
     enabled: true
-    
 
 - name: Install Local Path Provisioner
   kubernetes.core.k8s:


### PR DESCRIPTION
Currently after installing, RKE2 will not launch at startup and will need to be manually started. 