### PR TITLE
Change active state to active

### DIFF
--- a/roles/nfs_server/tasks/main.yaml
+++ b/roles/nfs_server/tasks/main.yaml
@@ -39,4 +39,4 @@
     permanent: false
   when:
   - cluster_interface is defined
-  - firewalld.status.ActiveState == 'started'
+  - firewalld.status.ActiveState == 'active'


### PR DESCRIPTION
Systemd does not list "started" as a valid state

https://www.freedesktop.org/software/systemd/man/latest/systemd.html

As such the task will be skipped and NFS will not be properly allowed