### PR TITLE
Add support for a nodeport proxy instead of metallb advertisement

### DIFF
--- a/hosts.yaml-example
+++ b/hosts.yaml-example
@@ -71,6 +71,24 @@ all:
     #  RKE2
     #
 
+    # Use a NodePort and host service proxy for cluster traffic ingress.
+    # Mutually exclusive with the metallb option.
+    # Fuzzball Kong ingress configurations will need to specify the following NodePort proxy configuration.
+    #   ingress:
+    #     create:
+    #       proxy:
+    #         type: NodePort
+    #         http:
+    #           nodePort: 30080
+    #         tls:
+    #           nodePort: 30443
+    nodeport_proxy: false
+
+    # Use metallb as the LoadBalancer solution for cluster traffic ingress.
+    # Mutually exclusive with the nodeport_proxy option. 
+    # LoadBalancer service configuration may need `metallb.universe.tf/loadBalancerIPs` annotations.
+    metallb: true
+
     # Customizations for the default metallb pool that Fuzzball
     # Orchestrate will use for external services.
     #

--- a/roles/fuzzball_orchestrate/defaults/main.yaml
+++ b/roles/fuzzball_orchestrate/defaults/main.yaml
@@ -35,11 +35,6 @@ fuzzball_orchestrate_defaults:
       storage:
         gossipService:
           type: NodePort
-      workflow:
-        callbackService:
-          type: LoadBalancer
-          annotations:
-            metallb.universe.tf/allow-shared-ip: "ingress-and-fuzzball"
     database:
       create:
         enableDebugPod: true

--- a/roles/rke2/defaults/main.yaml
+++ b/roles/rke2/defaults/main.yaml
@@ -22,3 +22,6 @@ metallb_advertisement_defaults:
     - default-pool
 
 metallb_advertisement: {}
+
+metallb: true
+nodeport_proxy: false

--- a/roles/rke2/tasks/main.yaml
+++ b/roles/rke2/tasks/main.yaml
@@ -56,52 +56,10 @@
 - name: Fix /opt/local-path-provisioner context for SELinux
   ansible.builtin.command: restorecon -rv /opt/local-path-provisioner
 
-- name: Install metallb
-  kubernetes.core.k8s:
-    state: present
-    src: https://raw.githubusercontent.com/metallb/metallb/v0.14.5/config/manifests/metallb-native.yaml
-    kubeconfig: "{{ kubeconfig }}"
-  register: result
-  retries: 10
-  delay: 10
-  until: result.failed is not defined or result.failed == false
+- name: Install NodePort Proxy for ingress
+  import_tasks: nodeport_proxy.yaml
+  when: nodeport_proxy == true
 
-- name: Configure metallb pool
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ metallb_pool_defaults | ansible.builtin.combine(metallb_pool, recursive=true) }}"
-    kubeconfig: "{{ kubeconfig }}"
-  register: result
-  retries: 10
-  delay: 10
-  until: result.failed is not defined or result.failed == false
-
-- name: Configure metallb advertisement
-  kubernetes.core.k8s:
-    state: present
-    definition: "{{ metallb_advertisement_defaults | ansible.builtin.combine(metallb_advertisement, recursive=true) }}"
-    kubeconfig: "{{ kubeconfig }}"
-
-# - name: Disable RKE2 ingress hostPorts
-#   kubernetes.core.k8s:
-#     state: present
-#     apply: true
-#     definition:
-#       apiVersion: apps/v1
-#       kind: DaemonSet
-#       metadata:
-#         name: rke2-ingress-nginx-controller
-#         namespace: kube-system
-#       spec:
-#         template:
-#           spec:
-#             containers:
-#             - name: rke2-ingress-nginx-controller
-#               ports:
-#               - containerPort: 80
-#                 name: http
-#                 hostPort: null
-#               - containerPort: 443
-#                 name: https
-#                 hostPort: null
-#     kubeconfig: /etc/rancher/rke2/rke2.yaml
+- name: Install metallb for ingress
+  import_tasks: metallb.yaml
+  when: metallb == true

--- a/roles/rke2/tasks/metallb.yaml
+++ b/roles/rke2/tasks/metallb.yaml
@@ -1,0 +1,27 @@
+---
+
+- name: Install metallb
+  kubernetes.core.k8s:
+    state: present
+    src: https://raw.githubusercontent.com/metallb/metallb/v0.14.5/config/manifests/metallb-native.yaml
+    kubeconfig: "{{ kubeconfig }}"
+  register: result
+  retries: 10
+  delay: 10
+  until: result.failed is not defined or result.failed == false
+
+- name: Configure metallb pool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ metallb_pool_defaults | ansible.builtin.combine(metallb_pool, recursive=true) }}"
+    kubeconfig: "{{ kubeconfig }}"
+  register: result
+  retries: 10
+  delay: 10
+  until: result.failed is not defined or result.failed == false
+
+- name: Configure metallb advertisement
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ metallb_advertisement_defaults | ansible.builtin.combine(metallb_advertisement, recursive=true) }}"
+    kubeconfig: "{{ kubeconfig }}"

--- a/roles/rke2/tasks/nodeport_proxy.yaml
+++ b/roles/rke2/tasks/nodeport_proxy.yaml
@@ -1,0 +1,32 @@
+---
+
+- name: Copy http proxy systemd service file
+  ansible.builtin.template:
+    src: templates/nodeport/proxy/http-proxy.service.j2
+    dest: /etc/systemd/system/http-proxy.service
+    mode: '0644'
+
+- name: Copy https proxy systemd service file
+  ansible.builtin.template:
+    src: templates/nodeport/proxy/https-proxy.service.j2
+    dest: /etc/systemd/system/https-proxy.service
+    mode: '0644'
+
+- name: Install socat
+  ansible.builtin.dnf:
+    name: socat
+    state: present
+
+- name: Enable and start http proxy
+  ansible.builtin.systemd:
+    name: http-proxy
+    enabled: yes
+    state: started
+    daemon_reload: true
+
+- name: Enable and start https proxy
+  ansible.builtin.systemd:
+    name: https-proxy
+    enabled: yes
+    state: started
+    daemon_reload: true

--- a/roles/rke2/templates/nodeport/proxy/http-proxy.service.j2
+++ b/roles/rke2/templates/nodeport/proxy/http-proxy.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=HTTP Proxy Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/socat TCP-LISTEN:80,fork TCP:0.0.0.0:30080
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/rke2/templates/nodeport/proxy/https-proxy.service.j2
+++ b/roles/rke2/templates/nodeport/proxy/https-proxy.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=HTTPS Proxy Service
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/socat TCP-LISTEN:443,fork TCP:0.0.0.0:30443
+Restart=always
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/rke2/templates/rancher/rke2/config.yaml
+++ b/roles/rke2/templates/rancher/rke2/config.yaml
@@ -6,3 +6,5 @@ cluster-cidr: {{ rke2_cluster_cidr }}
 {% if rke2_service_cidr is defined %}
 service-cidr: {{ rke2_service_cidr }}
 {% endif %}
+
+disable: rke2-ingress-nginx


### PR DESCRIPTION
- Remove commented out code
- Disables RKE2 nginx ingress deployments (unused by fuzzball)
- Adds nodeport_proxy configuration information to hosts.yaml-example
- Removes unused default fuzzball CRD `callbackService` configuration parameter