### PR TITLE
Fixes bool filter for when condition

### DIFF
--- a/roles/rke2/tasks/main.yaml
+++ b/roles/rke2/tasks/main.yaml
@@ -58,8 +58,8 @@
 
 - name: Install NodePort Proxy for ingress
   import_tasks: nodeport_proxy.yaml
-  when: nodeport_proxy == true
+  when: nodeport_proxy | bool
 
 - name: Install metallb for ingress
   import_tasks: metallb.yaml
-  when: metallb == true
+  when: metallb | bool


### PR DESCRIPTION
This PR improves the when conditions for the `metallb` and `nodeport_proxy` tasks by replacing direct comparisons to true with the `| bool` filter.

Using `== true` requires the variable to be a literal boolean, variables such as those from Ascenders _Variables_, may be strings or other types. The `| bool` filter correctly interprets all [truthy values](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_variables.html#boolean-variables), including strings. 